### PR TITLE
Fix typing for older python version

### DIFF
--- a/datalayer_core/authn/state.py
+++ b/datalayer_core/authn/state.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2023-2025 Datalayer, Inc.
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import annotations
+
+
 SERVER_PORT: int | None = None
 
 USER_HANDLE: str | None = None

--- a/datalayer_core/runtimes/exec/execapp.py
+++ b/datalayer_core/runtimes/exec/execapp.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023-2025 Datalayer, Inc.
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import annotations
+
 import json
 import signal
 import sys


### PR DESCRIPTION
Without this, we get issue when testing the conda package.