### PR TITLE
Add more time between tests and run in sequence to avoid runtime limits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
@@ -50,3 +51,5 @@ jobs:
           DATALAYER_TOKEN: ${{ secrets.DATALAYER_TEST_TOKEN }}
         run: |
           pytest datalayer_core/tests/ --cov=datalayer_core --cov-report term-missing
+
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://pypi.org/project/datalayer-core/"><img src="https://img.shields.io/pypi/v/datalayer-core.svg" alt="PyPI version"></img></a>
   <a href="https://github.com/datalayer/core/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" alt="License"></img></a>
   <a href="https://docs.datalayer.app/"><img src="https://img.shields.io/badge/docs-datalayer.app-blue" alt="Documentation"></img></a>
+  <a href="https://github.com/datalayer/core/actions/workflows/tests.yml"><img src="https://github.com/datalayer/core/actions/workflows/tests.yml/badge.svg" alt="Units Tests"></img></a>
 </p>
 
 ## Overview

--- a/datalayer_core/tests/test_sdk.py
+++ b/datalayer_core/tests/test_sdk.py
@@ -80,6 +80,7 @@ def test_runtime_create_execute_and_list() -> None:
     """
     Test the creation and deletion of runtime.
     """
+    time.sleep(10)
     # Create a secret
     client = DatalayerClient(token=DATALAYER_TEST_TOKEN)
     runtime_name = f"test_runtime-{uuid.uuid4()}"
@@ -92,6 +93,7 @@ def test_runtime_create_execute_and_list() -> None:
         assert response.stdout.strip() == "test"
 
         assert len(client.list_runtimes()) == 1
+    time.sleep(10)
 
 
 @pytest.mark.skipif(
@@ -102,6 +104,7 @@ def test_runtime_snapshot_create_and_delete() -> None:
     """
     Test the creation and deletion of runtime.
     """
+    time.sleep(10)
     client = DatalayerClient(token=DATALAYER_TEST_TOKEN)
     runtime_name = f"test_runtime-{uuid.uuid4()}"
     snapshot_name = f"test_snapshot-{uuid.uuid4()}"
@@ -124,6 +127,7 @@ def test_runtime_snapshot_create_and_delete() -> None:
         assert client.delete_snapshot(snapshot)["success"]
         assert client.delete_snapshot(snapshot_2)["success"]
         assert client.delete_snapshot(snapshot_3)["success"]
+    time.sleep(10)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This should fix tests passing on merge :) 